### PR TITLE
feat(app): Implement configuration file. Close #44

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -169,6 +169,7 @@
 
   <script src="scripts/controllers/create.js"></script>
   <script src="scripts/controllers/load.js"></script>
+  <script src="scripts/services/config.js"></script>
   <script src="scripts/services/model.js"></script>
   <script src="scripts/services/diagram.js"></script>
   <!-- endbuild -->

--- a/app/scripts/controllers/create.coffee
+++ b/app/scripts/controllers/create.coffee
@@ -16,6 +16,28 @@ angular.module('seaspongeApp')
         $scope.authors = "Glavin Wiechert"
         $scope.version = "0.0.0"
 
+        # Load Configuration from JSON string
+        loadJSON = (data) ->
+            # Data = JSON string
+            # console.log('data', data)
+            try
+                serialized = JSON.parse(data)
+                # console.log(serialized)
+                model.setConfiguration(serialized)
+                # console.log(model)
+            catch e
+                console.warn(e)
+
+        $scope.loadFile = (element) ->
+            # console.log('loadFile', arguments)
+            $scope.$apply (scope) ->
+                reader = new FileReader()
+                reader.onload = ->
+                    $scope.$apply (scope) ->
+                        data = reader.result
+                        loadJSON(data)
+                reader.readAsText(element.files[0])
+
         $scope.createModel = ->
             # Validate input
             # TODO
@@ -27,5 +49,4 @@ angular.module('seaspongeApp')
 
             # Transition to Draw route
             $location.path('/draw')
-
     ]

--- a/app/scripts/controllers/create.coffee
+++ b/app/scripts/controllers/create.coffee
@@ -8,7 +8,7 @@
  # Controller of the seaspongeApp
 ###
 angular.module('seaspongeApp')
-  .controller 'CreateController', ['$scope', '$location', 'model', ($scope, $location, model) ->
+  .controller 'CreateController', ['$scope', '$location', 'model', 'config', ($scope, $location, model, config) ->
     
         console.log('model', model);
 
@@ -23,7 +23,7 @@ angular.module('seaspongeApp')
             try
                 serialized = JSON.parse(data)
                 # console.log(serialized)
-                model.setConfiguration(serialized)
+                config.setConfiguration(serialized)
                 # console.log(model)
             catch e
                 console.warn(e)

--- a/app/scripts/controllers/draw.coffee
+++ b/app/scripts/controllers/draw.coffee
@@ -68,18 +68,9 @@ angular.module('seaspongeApp')
         "Other"
     ]
 
-    $scope.dataClassificationOptions = [
-        "public"
-        "internal"
-        "restricted"
-        "secret"
-        ]
+    $scope.dataClassificationOptions = model.dataClassificationOptions
 
-    $scope.securityControlOptions = [
-        "confidentiality"
-        "integrity"
-        "availability"
-    ]
+    $scope.securityControlOptions = model.securityControlOptions
 
     # Get container
     $scope.container = $('.diagram-contents')

--- a/app/scripts/controllers/draw.coffee
+++ b/app/scripts/controllers/draw.coffee
@@ -8,9 +8,10 @@
  # Controller of the seaspongeApp
 ###
 angular.module('seaspongeApp')
-  .controller 'DrawController', ['$scope', '$location', 'Stencils', 'model', ($scope, $location, Stencils, model) ->
+  .controller 'DrawController', ['$scope', '$location', 'Stencils', 'model', 'config', ($scope, $location, Stencils, model, config) ->
 
     $scope.model = model
+    $scope.config = config
     $scope.stencils = Stencils
     $scope.stencilQuery = ''
     $scope.shareLink = null
@@ -41,32 +42,6 @@ angular.module('seaspongeApp')
     $scope.selectedDiagram = null
 
     # UI
-    $scope.codeTypeOptions = [
-        "Not selected"
-        "Managed"
-        "Unmanaged"
-    ]
-    $scope.runningAsOptions = [
-        "Kernel"
-        "System"
-        "Network Service"
-        "Local Service"
-        "Administrator"
-        "Standard User with Elevation"
-        "Standard User without Elevation"
-        "Windows Store App"
-    ]
-    $scope.acceptsInputOptions = [
-        "Not Selected"
-        "Any Remote User or Entity"
-        "Kernel, System, or Local Admin"
-        "Local or Network Service"
-        "Local Standard User With Elevation"
-        "Local Standard User Without Elevation"
-        "Windows Store Apps or App Container Processes"
-        "Nothing"
-        "Other"
-    ]
 
     $scope.dataClassificationOptions = model.dataClassificationOptions
 

--- a/app/scripts/services/config.coffee
+++ b/app/scripts/services/config.coffee
@@ -1,0 +1,61 @@
+'use strict'
+
+###*
+ # @ngdoc service
+ # @name seaspongeApp.config
+ # @description
+ # # configurationu
+ # Factory in the seaspongeApp.
+###
+angular.module('seaspongeApp')
+    .factory('config', [ ->
+
+
+        config = {
+
+            setConfiguration: (serialized) ->
+                @dataClassificationOptions = serialized.dataClassificationOptions
+                @securityControlOptions = serialized.securityControlOptions
+                return @
+            
+            codeTypeOptions: [
+                "Not selected"
+                "Managed"
+                "Unmanaged"
+            ]
+            runningAsOptions: [
+                "Kernel"
+                "System"
+                "Network Service"
+                "Local Service"
+                "Administrator"
+                "Standard User with Elevation"
+                "Standard User without Elevation"
+                "Windows Store App"
+            ]
+            acceptsInputOptions: [
+                "Not Selected"
+                "Any Remote User or Entity"
+                "Kernel, System, or Local Admin"
+                "Local or Network Service"
+                "Local Standard User With Elevation"
+                "Local Standard User Without Elevation"
+                "Windows Store Apps or App Container Processes"
+                "Nothing"
+                "Other"
+            ]
+            dataClassificationOptions: [
+                "public"
+                "internal"
+                "restricted"
+                "secret"
+            ]
+            securityControlOptions: [
+                "confidentiality"
+                "integrity"
+                "availability"
+            ]
+        }
+
+        return config # Return Model instance
+    ])

--- a/app/scripts/services/model.coffee
+++ b/app/scripts/services/model.coffee
@@ -21,6 +21,17 @@ angular.module('seaspongeApp')
             threats: ""
             notes: ""
             diagrams: null
+            dataClassificationOptions: [
+                "public"
+                "internal"
+                "restricted"
+                "secret"
+            ]
+            securityControlOptions: [
+                "confidentiality"
+                "integrity"
+                "availability"
+            ]
 
             # Class Methods
 
@@ -37,12 +48,21 @@ angular.module('seaspongeApp')
             removeDiagram: (diagram) ->
                 @diagrams.remove(diagram)
 
+            setConfiguration: (serialized) =>
+                @dataClassificationOptions = serialized.dataClassificationOptions
+                @securityControlOptions = serialized.securityControlOptions
+                return
+
             serialize: =>
                 serialized = {
                     title: @title
                     version: @version
                     date: new Date()
                     authors: @authors
+                    configuration: {
+                        dataClassificationOptions: @dataClassificationOptions
+                        securityControlOptions: @securityControlOptions
+                    }
                     threats: @threats
                     notes: @notes
                     diagrams: (diagram.serialize() for diagram in @diagrams)
@@ -55,6 +75,8 @@ angular.module('seaspongeApp')
                 @version = serialized.version
                 @authors = serialized.authors
                 @threats = serialized.threats
+                @dataClassificationOptions = serialized.configuration.dataClassificationOptions
+                @securityControlOptions = serialized.configuration.securityControlOptions
                 @notes = serialized.notes
                 # Nested
                 @diagrams = (@addDiagram().deserialize(diagram) for diagram in serialized.diagrams)

--- a/app/scripts/services/model.coffee
+++ b/app/scripts/services/model.coffee
@@ -8,7 +8,7 @@
  # Factory in the seaspongeApp.
 ###
 angular.module('seaspongeApp')
-    .factory('model', ['Diagram', (Diagram) ->
+    .factory('model', ['Diagram', 'config', (Diagram, config) ->
 
         class Model
 
@@ -21,17 +21,6 @@ angular.module('seaspongeApp')
             threats: ""
             notes: ""
             diagrams: null
-            dataClassificationOptions: [
-                "public"
-                "internal"
-                "restricted"
-                "secret"
-            ]
-            securityControlOptions: [
-                "confidentiality"
-                "integrity"
-                "availability"
-            ]
 
             # Class Methods
 
@@ -48,11 +37,6 @@ angular.module('seaspongeApp')
             removeDiagram: (diagram) ->
                 @diagrams.remove(diagram)
 
-            setConfiguration: (serialized) =>
-                @dataClassificationOptions = serialized.dataClassificationOptions
-                @securityControlOptions = serialized.securityControlOptions
-                return
-
             serialize: =>
                 serialized = {
                     title: @title
@@ -60,8 +44,8 @@ angular.module('seaspongeApp')
                     date: new Date()
                     authors: @authors
                     configuration: {
-                        dataClassificationOptions: @dataClassificationOptions
-                        securityControlOptions: @securityControlOptions
+                        dataClassificationOptions: config.dataClassificationOptions
+                        securityControlOptions: config.securityControlOptions
                     }
                     threats: @threats
                     notes: @notes
@@ -75,8 +59,8 @@ angular.module('seaspongeApp')
                 @version = serialized.version
                 @authors = serialized.authors
                 @threats = serialized.threats
-                @dataClassificationOptions = serialized.configuration.dataClassificationOptions
-                @securityControlOptions = serialized.configuration.securityControlOptions
+                config.dataClassificationOptions = serialized.configuration.dataClassificationOptions
+                config.securityControlOptions = serialized.configuration.securityControlOptions
                 @notes = serialized.notes
                 # Nested
                 @diagrams = (@addDiagram().deserialize(diagram) for diagram in serialized.diagrams)

--- a/app/views/create.html
+++ b/app/views/create.html
@@ -38,6 +38,11 @@
             placeholder="Version" ng-model="version">
           </div>
 
+          <div class="form-group">
+            <label for="config">Configuration File</label>
+            <input type="file" class="load-form" id="config-file" onchange="angular.element(this).scope().loadFile(this)">
+          </div>
+
           <button type="submit" class="btn btn-default" ng-click="createModel()">Start Modeling!</button>
 
         </form>

--- a/app/views/draw.html
+++ b/app/views/draw.html
@@ -320,7 +320,7 @@
             <div class="form-group">
               <label for="properties-codeType" class="">Code Type</label>
               <select class="form-control" id="properties-codeType"
-              ng-options="codeType for codeType in codeTypeOptions"
+              ng-options="codeType for codeType in config.codeTypeOptions"
               ng-model="selectedStencil.codeType">
               </select>
             </div>
@@ -329,7 +329,7 @@
               <label for="properties-runningAs" class="">Running As</label>
               <select class="form-control" id="properties-runningAs"
               ng-model="selectedStencil.runningAs"
-              ng-options="runningAs for runningAs in runningAsOptions">
+              ng-options="runningAs for runningAs in config.runningAsOptions">
               </select>
             </div>
 
@@ -337,7 +337,7 @@
               <label for="properties-acceptsInput" class="">Accepts Input From</label>
               <select class="form-control" id="properties-acceptsInput"
               ng-model="selectedStencil.acceptsInput"
-              ng-options="acceptsInput for acceptsInput in acceptsInputOptions">
+              ng-options="acceptsInput for acceptsInput in config.acceptsInputOptions">
               </select>
             </div>
 
@@ -407,7 +407,7 @@
                         <label for="properties-dataClassification-type" class="">Type</label>
                         <select class="form-control" id="properties-dataClassification-type"
                         ng-model="dataClassification.type"
-                        ng-options="dataClassificationOption for dataClassificationOption in dataClassificationOptions">
+                        ng-options="dataClassificationOption for dataClassificationOption in config.dataClassificationOptions">
                         </select>
                     </div>
                     <div class="form-group">
@@ -443,7 +443,7 @@
                         <label for="properties-securityControl-type" class="">Type</label>
                         <select class="form-control" id="properties-securityControl-type"
                         ng-model="securityControl.type"
-                        ng-options="securityControlOption for securityControlOption in securityControlOptions">
+                        ng-options="securityControlOption for securityControlOption in config.securityControlOptions">
                         </select>
                     </div>
                     <div class="form-group">


### PR DESCRIPTION
This implements loading a configuration file at time of model creation. It also saves and loads the configuration during (de)serialization to avoid having to worry about it at load time.

A sample config file (so far is)
```
{
	"dataClassificationOptions" : [
        "public",
        "internal",
        "restricted",
        "secret"
    ],

    "securityControlOptions" : [
        "confidentiality",
        "integrity",
        "availability"
    ]
}
```